### PR TITLE
Use cmake version in code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 
 project(cornrow)
 
+set(CORNROW_VERSION "1.0.0")
+
 include(cmake/CPM.cmake)
 
 set(CMAKE_AUTOMOC ON)
@@ -28,6 +30,6 @@ set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS adduser)
 SET(CPACK_PACKAGE_DESCRIPTION "Bluetooth audio player")
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "This daemon accepts and plays audio from any Bluetooth source and turns your linux PC into a Bluetooth speaker.")
-SET(CPACK_PACKAGE_VERSION   "1.0.0")
+SET(CPACK_PACKAGE_VERSION CORNROW_VERSION)
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${PROJECT_SOURCE_DIR}/debian/postinst;${PROJECT_SOURCE_DIR}/debian/postrm;${PROJECT_SOURCE_DIR}/debian/install")
 include(CPack)

--- a/cornrowd/CMakeLists.txt
+++ b/cornrowd/CMakeLists.txt
@@ -21,6 +21,8 @@ target_link_libraries(${PROJECT_NAME}
     config
 )
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE CORNROW_VERSION="${CORNROW_VERSION}")
+
 install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION bin
 )

--- a/cornrowd/src/main.cpp
+++ b/cornrowd/src/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
     QCoreApplication a(argc, argv);
     QCoreApplication::setApplicationName("cornrowd");
-    QCoreApplication::setApplicationVersion("0.8.1");
+    QCoreApplication::setApplicationVersion(CORNROW_VERSION);
 
     // Parse command line options
     QCommandLineParser parser;


### PR DESCRIPTION
Use a compile definition to pass the cmake version  to the code.

Closes #38 